### PR TITLE
Change RSO Check

### DIFF
--- a/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SuggestRSOScreen.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/client/gui/SuggestRSOScreen.java
@@ -21,7 +21,7 @@ public class SuggestRSOScreen extends Screen {
     private MultilineText lines = MultilineText.EMPTY;
 
     public SuggestRSOScreen(Screen prevScreen) {
-        super(Text.literal("Reese's Sodium Options Suggestion"));
+        super(Text.literal("TexTrue's Rubidium Options Suggestion"));
         this.prevScreen = prevScreen;
     }
 
@@ -30,8 +30,8 @@ public class SuggestRSOScreen extends Screen {
         super.init();
         this.lines = MultilineText.create(this.textRenderer, MESSAGE, this.width - 50);
         int i = (this.lines.count() + 1) * this.textRenderer.fontHeight * 2;
-        this.addDrawableChild(new ButtonWidget(this.width / 2 - 155, 130 + i, 150, 20, Text.literal("CurseForge"), buttonWidget -> Util.getOperatingSystem().open("https://curseforge.com/minecraft/mc-mods/reeses-sodium-options")));
-        this.addDrawableChild(new ButtonWidget(this.width / 2 - 155 + 160, 130 + i, 150, 20, Text.literal("Modrinth"), buttonWidget -> Util.getOperatingSystem().open("https://modrinth.com/mod/reeses-sodium-options")));
+        this.addDrawableChild(new ButtonWidget(this.width / 2 - 155, 130 + i, 150, 20, Text.literal("CurseForge"), buttonWidget -> Util.getOperatingSystem().open("https://curseforge.com/minecraft/mc-mods/textrues-rubidium-options")));
+        this.addDrawableChild(new ButtonWidget(this.width / 2 - 155 + 160, 130 + i, 150, 20, Text.literal("Modrinth"), buttonWidget -> Util.getOperatingSystem().open("https://modrinth.com/mod/textrues-rubidium-options")));
         this.addDrawableChild(new ButtonWidget(this.width / 2 - 155, 100 + i, 150, 20, ScreenTexts.PROCEED, buttonWidget -> {
             if (this.checkbox.isChecked()) {
                 SodiumExtraClientMod.options().notificationSettings.hideRSORecommendation = true;

--- a/src/main/java/me/flashyreese/mods/sodiumextra/mixin/compat/MixinTitleScreen.java
+++ b/src/main/java/me/flashyreese/mods/sodiumextra/mixin/compat/MixinTitleScreen.java
@@ -20,7 +20,7 @@ public abstract class MixinTitleScreen extends Screen {
 
     @Inject(method = "init", at = @At(value = "RETURN"))
     private void postInit(CallbackInfo ci) {
-        if (!ModList.get().isLoaded("reeses-sodium-options") && !SodiumExtraClientMod.options().notificationSettings.hideRSORecommendation && !SodiumExtraClientMod.options().hasSuggestedRSO()) {
+        if (!ModList.get().isLoaded("reeses_sodium_options") && !SodiumExtraClientMod.options().notificationSettings.hideRSORecommendation && !SodiumExtraClientMod.options().hasSuggestedRSO()) {
             this.client.setScreen(new SuggestRSOScreen(this));
             SodiumExtraClientMod.options().setSuggestedRSO(true);
         }

--- a/src/main/resources/assets/sodium-extra/lang/cs_cz.json
+++ b/src/main/resources/assets/sodium-extra/lang/cs_cz.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / prům. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Aktualizace světel zakázány",
-  "sodium-extra.suggestRSO.header": "Návrh: Nainstalujte Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "Je velmi doporučeno nainstalovat Reese's Sodium Options společně se Sodium Extra. Kvůli rostoucímu množství funkcí, již nezapadají do možností Sodium."
+  "sodium-extra.suggestRSO.header": "Návrh: Nainstalujte TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "Je velmi doporučeno nainstalovat TexTrue's Rubidium Options společně se Rubidium Extra. Kvůli rostoucímu množství funkcí, již nezapadají do možností Rubidium."
 }

--- a/src/main/resources/assets/sodium-extra/lang/de_de.json
+++ b/src/main/resources/assets/sodium-extra/lang/de_de.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(Max. %s / Dsl. %s / Min. %s)",
   "sodium-extra.overlay.light_updates": "Schatten Aktualisierung deaktiviert",
-  "sodium-extra.suggestRSO.header": "Vorschlag: Installiere Reese's Sodium Options Mod",
-  "sodium-extra.suggestRSO.message": "Es wird dringend empfohlen, dass du Reese's Sodium Optionen neben Sodium Extra. Aufgrund der wachsenden Anzahl an Funktionen passt es nicht mehr richtig in die Videooptionen von Sodium rein."
+  "sodium-extra.suggestRSO.header": "Vorschlag: Installiere TexTrue's Rubidium Options Mod",
+  "sodium-extra.suggestRSO.message": "Es wird dringend empfohlen, dass du Reese's Sodium Optionen neben Rubidium Extra. Aufgrund der wachsenden Anzahl an Funktionen passt es nicht mehr richtig in die Videooptionen von Rubidium rein."
 }

--- a/src/main/resources/assets/sodium-extra/lang/el_gr.json
+++ b/src/main/resources/assets/sodium-extra/lang/el_gr.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / avg. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Light updates disabled",
-  "sodium-extra.suggestRSO.header": "Suggestion: Install Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "It is highly recommended you install Reese's Sodium Options alongside Sodium Extra. Due to the growing amount of features, it no longer fits properly on Sodium's video options."
+  "sodium-extra.suggestRSO.header": "Suggestion: Install TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "It is highly recommended you install TexTrue's Rubidium Options alongside Rubidium Extra. Due to the growing amount of features, it no longer fits properly on Rubidium's video options."
 }

--- a/src/main/resources/assets/sodium-extra/lang/en_us.json
+++ b/src/main/resources/assets/sodium-extra/lang/en_us.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / avg. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Light updates disabled",
-  "sodium-extra.suggestRSO.header": "Suggestion: Install Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "It is highly recommended you install Reese's Sodium Options alongside Sodium Extra. Due to the growing amount of features, it no longer fits properly on Sodium's video options."
+  "sodium-extra.suggestRSO.header": "Suggestion: Install TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "It is highly recommended you install TexTrue's Rubidium Options alongside Rubidium Extra. Due to the growing amount of features, it no longer fits properly on Rubidium's video options."
 }

--- a/src/main/resources/assets/sodium-extra/lang/es_mx.json
+++ b/src/main/resources/assets/sodium-extra/lang/es_mx.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / prom. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Actualizaciones de iluminación deshabilitado",
-  "sodium-extra.suggestRSO.header": "Sugerencia: Instale Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "Se recomienda enfáticamente que instale Reese's Sodium Options junto con Sodium Extra. Debido a la creciente cantidad de funciones, ya no encaja correctamente en las opciones de video de Sodium."
+  "sodium-extra.suggestRSO.header": "Sugerencia: Instale TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "Se recomienda enfáticamente que instale TexTrue's Rubidium Options junto con Rubidium Extra. Debido a la creciente cantidad de funciones, ya no encaja correctamente en las opciones de video de Rubidium."
 }

--- a/src/main/resources/assets/sodium-extra/lang/et_ee.json
+++ b/src/main/resources/assets/sodium-extra/lang/et_ee.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s k/s",
   "sodium-extra.overlay.fps_extended": "(max. %s / kesk. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Valguse uuendused keelatud",
-  "sodium-extra.suggestRSO.header": "Soovitus: paigalda Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "Tungivalt soovitatav on paigaldada Sodium Extra kõrvale Reese's Sodium Options. Kasvava funktsionaalsuse tõttu ei mahu valikud enam Sodiumi graafikasätetesse ära."
+  "sodium-extra.suggestRSO.header": "Soovitus: paigalda TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "Tungivalt soovitatav on paigaldada Rubidium Extra kõrvale TexTrue's Rubidium Options. Kasvava funktsionaalsuse tõttu ei mahu valikud enam Rubidiumi graafikasätetesse ära."
 }

--- a/src/main/resources/assets/sodium-extra/lang/fr_fr.json
+++ b/src/main/resources/assets/sodium-extra/lang/fr_fr.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s IPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / moy. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Mises à jour de l'éclairage désactivé",
-  "sodium-extra.suggestRSO.header": "Suggestion : Installer Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "Il est fortement recommandé d'installer Reese's Sodium Options à côté de Sodium extra. En raison de la quantité croissante de fonctionnalités, il ne convient plus correctement aux options vidéo de Sodium."
+  "sodium-extra.suggestRSO.header": "Suggestion : Installer TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "Il est fortement recommandé d'installer TexTrue's Rubidium Options à côté de Rubidium Extra. En raison de la quantité croissante de fonctionnalités, il ne convient plus correctement aux options vidéo de Rubidium."
 }

--- a/src/main/resources/assets/sodium-extra/lang/it_it.json
+++ b/src/main/resources/assets/sodium-extra/lang/it_it.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / med. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Light updates disabled",
-  "sodium-extra.suggestRSO.header": "Suggestion: Install Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "It is highly recommended you install Reese's Sodium Options alongside Sodium Extra. Due to the growing amount of features, it no longer fits properly on Sodium's video options."
+  "sodium-extra.suggestRSO.header": "Suggestion: Install TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "It is highly recommended you install TexTrue's Rubidium Options alongside Rubidium Extra. Due to the growing amount of features, it no longer fits properly on Rubidium's video options."
 }

--- a/src/main/resources/assets/sodium-extra/lang/ja_jp.json
+++ b/src/main/resources/assets/sodium-extra/lang/ja_jp.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(最大 %s / 平均 %s / 最小 %s)",
   "sodium-extra.overlay.light_updates": "光の状態の更新が無効",
-  "sodium-extra.suggestRSO.header": "提案: Reese's Sodium Optionsをインストールしましょう",
-  "sodium-extra.suggestRSO.message": "機能の増加により、Sodiumのビデオ設定に適切に収まらないことがあるので、Reese's Sodium OptionsをSodium Extraと一緒にインストールすることを強くお勧めします。"
+  "sodium-extra.suggestRSO.header": "提案: TexTrue's Rubidium Optionsをインストールしましょう",
+  "sodium-extra.suggestRSO.message": "機能の増加により、Rubidiumのビデオ設定に適切に収まらないことがあるので、TexTrue's Rubidium OptionsをRubidium Extraと一緒にインストールすることを強くお勧めします。"
 }

--- a/src/main/resources/assets/sodium-extra/lang/ko_kr.json
+++ b/src/main/resources/assets/sodium-extra/lang/ko_kr.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(최대 %s / 평균 %s / 최소 %s)",
   "sodium-extra.overlay.light_updates": "조명 업데이트 비활성화됨",
-  "sodium-extra.suggestRSO.header": "Reese's Sodium Options 모드를 설치하는것을 추천합니다.",
-  "sodium-extra.suggestRSO.message": "Sodium Extra와 함께 Reese's Sodium Options 모드를 설치하는것이 좋습니다. 기능의 수가 증가함에 따라 Sodium의 비디오 옵션에서 모두 표시되지 않을 수 있습니다."
+  "sodium-extra.suggestRSO.header": "TexTrue's Rubidium Options 모드를 설치하는것을 추천합니다.",
+  "sodium-extra.suggestRSO.message": "Rubidium Extra와 함께 TexTrue's Rubidium Options 모드를 설치하는것이 좋습니다. 기능의 수가 증가함에 따라 Rubidium의 비디오 옵션에서 모두 표시되지 않을 수 있습니다."
 }

--- a/src/main/resources/assets/sodium-extra/lang/pl_pl.json
+++ b/src/main/resources/assets/sodium-extra/lang/pl_pl.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(maks. %s / śr. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Aktualizacje oświetlenia wyłączone",
-  "sodium-extra.suggestRSO.header": "Sugestia: Zainstaluj Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "Wysoce rekomendowane jest zainstalowanie moda Reese's Sodium Options wraz z Sodium Extra. Przez ciągle zwiększającą się liczbę funkcji, opcje nie mieszczą się na ekranie ustawień Sodium."
+  "sodium-extra.suggestRSO.header": "Sugestia: Zainstaluj TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "Wysoce rekomendowane jest zainstalowanie moda TexTrue's Rubidium Options wraz z Rubidium Extra. Przez ciągle zwiększającą się liczbę funkcji, opcje nie mieszczą się na ekranie ustawień Rubidium."
 }

--- a/src/main/resources/assets/sodium-extra/lang/pt_br.json
+++ b/src/main/resources/assets/sodium-extra/lang/pt_br.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "Taxa de quadros: %s",
   "sodium-extra.overlay.fps_extended": "(max. %s / avg. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Light updates disabled",
-  "sodium-extra.suggestRSO.header": "Suggestion: Install Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "It is highly recommended you install Reese's Sodium Options alongside Sodium Extra. Due to the growing amount of features, it no longer fits properly on Sodium's video options."
+  "sodium-extra.suggestRSO.header": "Suggestion: Install TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "It is highly recommended you install TexTrue's Rubidium Options alongside Rubidium Extra. Due to the growing amount of features, it no longer fits properly on Rubidium's video options."
 }

--- a/src/main/resources/assets/sodium-extra/lang/ru_ru.json
+++ b/src/main/resources/assets/sodium-extra/lang/ru_ru.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(макс. %s / сред. %s / мин. %s)",
   "sodium-extra.overlay.light_updates": "Обновления света отключены",
-  "sodium-extra.suggestRSO.header": "Совет: установите Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "Крайне рекомендуется использовать Reese's Sodium Options совместно с Sodium Extra. Из-за возрастающего количества функций его элементы не умещаются должным образом в обычном окне настроек графики Sodium."
+  "sodium-extra.suggestRSO.header": "Совет: установите TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "Крайне рекомендуется использовать TexTrue's Rubidium Options совместно с Rubidium Extra. Из-за возрастающего количества функций его элементы не умещаются должным образом в обычном окне настроек графики Rubidium."
 }

--- a/src/main/resources/assets/sodium-extra/lang/th_th.json
+++ b/src/main/resources/assets/sodium-extra/lang/th_th.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(สูง %s / กลาง %s / ต่ำ %s)",
   "sodium-extra.overlay.light_updates": "Light updates disabled",
-  "sodium-extra.suggestRSO.header": "Suggestion: Install Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "It is highly recommended you install Reese's Sodium Options alongside Sodium Extra. Due to the growing amount of features, it no longer fits properly on Sodium's video options."
+  "sodium-extra.suggestRSO.header": "Suggestion: Install TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "It is highly recommended you install TexTrue's Rubidium Options alongside Rubidium Extra. Due to the growing amount of features, it no longer fits properly on Rubidium's video options."
 }

--- a/src/main/resources/assets/sodium-extra/lang/tr_tr.json
+++ b/src/main/resources/assets/sodium-extra/lang/tr_tr.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(mak. %s / ort. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "Işık güncellemeleri devre dışı",
-  "sodium-extra.suggestRSO.header": "Öneri: Reese's Sodium Options modunu indirin",
-  "sodium-extra.suggestRSO.message": "Sodium Extra'nın yanı sıra Reese's Sodium Options modunu kurmanız şiddetle tavsiye edilir. Artan sayıda özellik nedeniyle, artık Sodium'un video seçeneklerine tam olarak uymuyor."
+  "sodium-extra.suggestRSO.header": "Öneri: TexTrue's Rubidium Options modunu indirin",
+  "sodium-extra.suggestRSO.message": "Rubidium Extra'nın yanı sıra TexTrue's Rubidium Options modunu kurmanız şiddetle tavsiye edilir. Artan sayıda özellik nedeniyle, artık Rubidium'un video seçeneklerine tam olarak uymuyor."
 }

--- a/src/main/resources/assets/sodium-extra/lang/uk_ua.json
+++ b/src/main/resources/assets/sodium-extra/lang/uk_ua.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s кадр/с",
   "sodium-extra.overlay.fps_extended": "(макс. %s / серед. %s / мін. %s)",
   "sodium-extra.overlay.light_updates": "Оновлення світла вимкнено",
-  "sodium-extra.suggestRSO.header": "Порада: встановіть Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "Рекомендовано використовувати Reese's Sodium Options разом із Sodium Extra. Через зростаючу кількість функцій його елементи не вміщаються належним чином у звичайному вікні налаштувань графіки Sodium."
+  "sodium-extra.suggestRSO.header": "Порада: встановіть TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "Рекомендовано використовувати TexTrue's Rubidium Options разом із Rubidium Extra. Через зростаючу кількість функцій його елементи не вміщаються належним чином у звичайному вікні налаштувань графіки Rubidium."
 }

--- a/src/main/resources/assets/sodium-extra/lang/zh_cn.json
+++ b/src/main/resources/assets/sodium-extra/lang/zh_cn.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "(max. %s / avg. %s / min. %s)",
   "sodium-extra.overlay.light_updates": "光照更新已禁用",
-  "sodium-extra.suggestRSO.header": "建议: 安装Reese's Sodium Options",
-  "sodium-extra.suggestRSO.message": "强烈建议您在安装Sodium Extra的同时安装Reese's Sodium Options。由于越来越多的功能，它不再适合Sodium的视频设置。"
+  "sodium-extra.suggestRSO.header": "建议: 安装TexTrue's Rubidium Options",
+  "sodium-extra.suggestRSO.message": "强烈建议您在安装Rubidium Extra的同时安装TexTrue's Rubidium Options。由于越来越多的功能，它不再适合Rubidium的视频设置。"
 }

--- a/src/main/resources/assets/sodium-extra/lang/zh_tw.json
+++ b/src/main/resources/assets/sodium-extra/lang/zh_tw.json
@@ -172,6 +172,6 @@
   "sodium-extra.overlay.fps": "%s FPS",
   "sodium-extra.overlay.fps_extended": "（最高 %s / 平均 %s / 最低 %s）",
   "sodium-extra.overlay.light_updates": "照明更新已停用",
-  "sodium-extra.suggestRSO.header": "建議：安裝 Reese's Sodium Options 模組",
-  "sodium-extra.suggestRSO.message": "由於功能選項的增加，Sodium 預設的顯示設定已無法相容，強烈建議您下載 Reese's Sodium Options 和 Sodium Extra 這兩個模組。"
+  "sodium-extra.suggestRSO.header": "建議：安裝 TexTrue's Rubidium Options 模組",
+  "sodium-extra.suggestRSO.message": "由於功能選項的增加，Rubidium 預設的顯示設定已無法相容，強烈建議您下載 TexTrue's Rubidium Options 和 Rubidium Extra 這兩個模組。"
 }


### PR DESCRIPTION
I ported RSO to the forge ([TexTrue's Rubidium Options](https://curseforge.com/minecraft/mc-mods/textrues-rubidium-options)), the original modid was illegal in the forge, I changed the original modid from reeses-sodium-options to reeses_sodium_options, but the modid of this module was not changed, this led to the installation of TexTrue's Rubidium Options but still suggested to install RSO, this PR fixes this problem.

(The modrinth page is under review)